### PR TITLE
Format tile again

### DIFF
--- a/datagouv_publisher.py
+++ b/datagouv_publisher.py
@@ -8,6 +8,10 @@ TRANSPORT_ORGANIZATION_ID = os.environ["TRANSPORT_ORGANIZATION_ID"]
 DATAGOUV_API_KEY = os.environ["DATAGOUV_API_KEY"]
 
 
+def _format_title_as_datagouv(title):
+    return title.replace("_", "-").lower()
+
+
 def find_community_resources(dataset_id, netex_file):
     """
     Checks if the a community resource already exists
@@ -24,7 +28,12 @@ def find_community_resources(dataset_id, netex_file):
 
     if data is not None:
         # Note: datagouv lowercase the file names, so we do the same
-        filtered = [r for r in data if r["title"].lower() == netex_file.lower()]
+        filtered = [
+            r
+            for r in data
+            if _format_title_as_datagouv(r["title"])
+            == _format_title_as_datagouv(netex_file)
+        ]
         logging.debug("community resources: %s", [r["title"] for r in data])
         if len(filtered) == 0:
             logging.debug("Found the dataset %s, but no existing ressource", dataset_id)

--- a/readme.md
+++ b/readme.md
@@ -29,3 +29,5 @@ Then you can run any function in the file like:
 The functions available are:
 * `get_all_netex`: print all the datasets with their netex community resources
 * `delete_all_netex`: delete the netex files created by transport.data.gouv.fr as community resource.
+* `get_netex_duplicates`: print all the datasets that have duplicated netex files (with same names)
+* `delete_old_netex_duplicates`: delete the old netex duplicates (only keep the last one)


### PR DESCRIPTION
replace `_` with `-` in resource title since datagouv does it. This should take care of the remaining duplicates.

also add 2 targets to the cli:

* `get_netex_duplicates`: print all the datasets that have duplicated netex files (with same names)
* `delete_old_netex_duplicates`: delete the old netex duplicates (only keep the last one)