### PR TITLE
resolve forgotten keyword argument

### DIFF
--- a/gtfs_converter/datagouv_publisher.py
+++ b/gtfs_converter/datagouv_publisher.py
@@ -67,7 +67,11 @@ def find_community_resources(dataset_id, new_file, resource_url, resource_format
     )
 
 
-def find_or_create_community_resource(dataset_id, new_file, url):
+def find_or_create_community_resource(
+        dataset_id,
+        new_file,
+        url,
+        resource_format):
     """
     When publishing a file, either the community resource already existed,
     then we only update the file.


### PR DESCRIPTION
There was a keyword forgotten in the find_or_create_community_resource function, that made all jobs fail.