### PR TITLE
Do not reuse all POST payload to update resource

### DIFF
--- a/gtfs_converter/api.py
+++ b/gtfs_converter/api.py
@@ -49,16 +49,15 @@ def _convert(conversion_type):
 
 
 def _allowed_file(filename):
-    return '.' in filename and \
-           filename.rsplit('.', 1)[1].lower() in ['zip']
+    return "." in filename and filename.rsplit(".", 1)[1].lower() in ["zip"]
 
 
 def _convert_to_geojson_sync():
     try:
-        if 'file' not in request.files:
+        if "file" not in request.files:
             return "no file"
-        file = request.files['file']
-        if file.filename == '':
+        file = request.files["file"]
+        if file.filename == "":
             return "no filename"
         if file and _allowed_file(file.filename):
             filename = secure_filename(file.filename)
@@ -80,7 +79,7 @@ def convert_gtfs_to_geojson():
     return _convert(["gtfs2geojson"])
 
 
-@app.route("/gtfs2geojson_sync", methods=['POST'])
+@app.route("/gtfs2geojson_sync", methods=["POST"])
 def convert_gtfs_to_geojson_sync():
     return _convert_to_geojson_sync()
 

--- a/gtfs_converter/datagouv_publisher.py
+++ b/gtfs_converter/datagouv_publisher.py
@@ -105,11 +105,9 @@ def update_resource_metadata(dataset_id, resource_id, additional_metadata, url):
     url = f"{DATAGOUV_API}/datasets/community_resources/{resource_id}/"
     headers = {"X-API-KEY": DATAGOUV_API_KEY}
 
-    logging.debug(f"update resource with payload: {resource}")
     ret = requests.put(url, headers=headers, json=resource)
-    logging.debug("pouet")
     ret.raise_for_status()
-    logging.debug("Updating of resource %s done: %s", resource_id, ret.json())
+    logging.debug("Updating of resource %s done", resource_id)
 
 
 def upload_resource(resource_id, filename):

--- a/gtfs_converter/datagouv_publisher.py
+++ b/gtfs_converter/datagouv_publisher.py
@@ -67,11 +67,7 @@ def find_community_resources(dataset_id, new_file, resource_url, resource_format
     )
 
 
-def find_or_create_community_resource(
-        dataset_id,
-        new_file,
-        url,
-        resource_format):
+def find_or_create_community_resource(dataset_id, new_file, url, resource_format):
     """
     When publishing a file, either the community resource already existed,
     then we only update the file.
@@ -87,7 +83,7 @@ def find_or_create_community_resource(
     return datagouv.create_community_resource(dataset_id, new_file)
 
 
-def update_resource_metadata(dataset_id, resource, additional_metadata, url):
+def update_resource_metadata(dataset_id, resource_id, additional_metadata, url):
     """
     Updates metadata of the resources.
 
@@ -97,18 +93,23 @@ def update_resource_metadata(dataset_id, resource, additional_metadata, url):
 
     Does not return
     """
-    logging.debug("Updating metadata of resource %s", resource["id"])
-    resource.update(additional_metadata)
-    resource["dataset"] = dataset_id
-    resource["organization"] = TRANSPORT_ORGANIZATION_ID
-    resource["extras"] = {ORIGINAL_URL_KEY: url}
+    resource = {
+        "id": resource_id,
+        "dataset": dataset_id,
+        "organization": TRANSPORT_ORGANIZATION_ID,
+        "extras": {ORIGINAL_URL_KEY: url},
+        **additional_metadata,
+    }
+    logging.debug("Updating metadata of resource %s", resource_id)
 
-    url = f"{DATAGOUV_API}/datasets/community_resources/{resource['id']}/"
+    url = f"{DATAGOUV_API}/datasets/community_resources/{resource_id}/"
     headers = {"X-API-KEY": DATAGOUV_API_KEY}
 
+    logging.debug(f"update resource with payload: {resource}")
     ret = requests.put(url, headers=headers, json=resource)
+    logging.debug("pouet")
     ret.raise_for_status()
-    logging.debug("Updating of resource %s done", resource["id"])
+    logging.debug("Updating of resource %s done: %s", resource_id, ret.json())
 
 
 def upload_resource(resource_id, filename):
@@ -141,7 +142,7 @@ def publish_to_datagouv(dataset_id, new_file, additional_metadata, url):
             dataset_id, new_file, url, resource_format=additional_metadata["format"]
         )
         update_resource_metadata(
-            dataset_id, community_resource, additional_metadata, url
+            dataset_id, community_resource["id"], additional_metadata, url
         )
         logging.info("Added %s to the dataset %s", new_file, dataset_id)
     except requests.HTTPError as err:

--- a/gtfs_converter/gtfs2geojson.py
+++ b/gtfs_converter/gtfs2geojson.py
@@ -26,6 +26,4 @@ def convert(gtfs_src, fname, tmp_dir):
 
 
 def convert_sync(gtfs_src):
-    return utils.run_command_get_stdout(
-        [GEOJSON_CONVERTER, "--input", gtfs_src]
-    )
+    return utils.run_command_get_stdout([GEOJSON_CONVERTER, "--input", gtfs_src])

--- a/gtfs_converter/jobs.py
+++ b/gtfs_converter/jobs.py
@@ -19,8 +19,7 @@ def convert(params):
 
             for conversion in params["conversion_type"]:
                 if conversion == "gtfs2netex":
-                    _convert_to_netex(
-                        gtfs, fname, params["datagouv_id"], params["url"])
+                    _convert_to_netex(gtfs, fname, params["datagouv_id"], params["url"])
                 if conversion == "gtfs2geojson":
                     _convert_to_geojson(
                         gtfs, fname, params["datagouv_id"], params["url"]

--- a/gtfs_converter/utils.py
+++ b/gtfs_converter/utils.py
@@ -66,7 +66,9 @@ def download_gtfs(url):
     local_filename, headers = urllib.request.urlretrieve(url)
 
     # we try to get the filename from the Content-Disposition header, else we get it from the url
-    fname_in_header = re.findall('filename="?([^"]+)"?', headers.get("Content-Disposition", ''))
+    fname_in_header = re.findall(
+        'filename="?([^"]+)"?', headers.get("Content-Disposition", "")
+    )
     if fname_in_header:
         fname = fname_in_header[0]
     else:


### PR DESCRIPTION
we were reusing all the payload given by the creation of a community resource (done with a http `POST`) to update the resource metadata (done with http `PUT`)

since we were reusing all the payload, we were forcing the value of the resource `url` to an old value.

now we only get use the resource's id from the payload

I also formated the code with back, the only important file to review is `datagouv_publisher.py`